### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -1,3 +1,4 @@
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -1,6 +1,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -6,6 +6,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -10,6 +10,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -11,6 +11,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -12,6 +12,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -9,6 +9,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -2,6 +2,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -4,6 +4,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -13,6 +13,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -1,5 +1,6 @@
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -7,6 +7,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -5,6 +5,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -3,6 +3,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -8,6 +8,7 @@
 
 
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`

--- a/README.yaml
+++ b/README.yaml
@@ -1,4 +1,5 @@
 
+
 ---
 #
 # This is the canonical configuration for the `README.md`


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143